### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Publish to Registry
       id: publish_to_registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GOBACKUP_DIST_TAG: ${{ steps.git_info.outputs.GOBACKUP_DIST_TAG }}
         GOBACKUP_DIST_FLAVOUR: ${{ steps.git_info.outputs.GOBACKUP_DIST_FLAVOUR }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore